### PR TITLE
Fix for drawColon

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -261,7 +261,7 @@ void Adafruit_7segment::writeDigitRaw(uint8_t d, uint8_t bitmask) {
 
 void Adafruit_7segment::drawColon(boolean state) {
   if (state)
-    displaybuffer[2] = 0x22;
+    displaybuffer[2] = 0x2;
   else
     displaybuffer[2] = 0;
 }


### PR DESCRIPTION
As written the backpack library turns on all 8 outputs for the "colon" row. This patch changes that to only set the output for the colon on big (1.2") 7-segment display. There still is no library control for the three other dots.
