### PR TITLE
Added function for Custom Colon Values

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -51,6 +51,8 @@
   } ///< 16-bit var swap
 #endif
 
+uint8_t colonValue;
+
 static const PROGMEM uint8_t sevensegfonttable[] = {
 
     0b00000000, // (space)
@@ -568,7 +570,7 @@ void Adafruit_BicolorMatrix::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
 /******************************* 7 SEGMENT OBJECT */
 
-Adafruit_7segment::Adafruit_7segment(void) { position = 0; }
+Adafruit_7segment::Adafruit_7segment(void) { position = 0; colonValue = 2; }
 
 void Adafruit_7segment::print(const String &c) { write(c.c_str(), c.length()); }
 
@@ -687,7 +689,7 @@ void Adafruit_7segment::writeDigitRaw(uint8_t d, uint8_t bitmask) {
 
 void Adafruit_7segment::drawColon(bool state) {
   if (state)
-    displaybuffer[2] = 0x2;
+    displaybuffer[2] = colonValue;
   else
     displaybuffer[2] = 0;
 }
@@ -811,4 +813,15 @@ void Adafruit_7segment::printError(void) {
   for (uint8_t i = 0; i < SEVENSEG_DIGITS; ++i) {
     writeDigitRaw(i, (i == 2 ? 0x00 : 0x40));
   }
+}
+
+
+void Adafruit_7segment::setColon(uint8_t value){
+	if(value>127)value = 127;
+	colonValue = value;
+}
+
+
+uint8_t Adafruit_7segment::getColon(void){
+	return colonValue;
 }

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -455,6 +455,20 @@ public:
     @brief  Issue colon-on directly to display (bypass buffer).
   */
   void writeColon(void);
+  
+  /*!
+    @brief  Set custom value for colon segment.
+    @param  8 bit value corresponding to the 7 possible segments.
+			max value 127.
+  */
+  
+  void setColon(uint8_t value);
+  
+  /*!
+    @brief  Returns the current value being used for the colon.
+  */
+  uint8_t getColon(void);
+  
 
 private:
   uint8_t position; ///< Current print position, 0-3


### PR DESCRIPTION
In order to provide versatility to which pin(s) are connected for the colon on custom displays, I've added a function that allows you to set the 8 bit value that will be used to display the colon.  The default value is still 2 to be compatible with Adafruit 7 segment displays.
I've compiled and tested with and LED backpack and all existing functions in the 7 segment example function as expected.